### PR TITLE
Cannot use ProxyCommand mode.

### DIFF
--- a/main.c
+++ b/main.c
@@ -1249,7 +1249,7 @@ int main(int argc, char *argv[])
 
     log_init();
 
-    while ((oc = getopt(argc, argv, "L:pi:C:s:f:P:dqhSF:DU:t:u:")) != -1)
+    while ((oc = getopt(argc, argv, "L:pi:C:s:f:W:dqhSF:DU:t:u:")) != -1)
     {
         switch(oc)
         {


### PR DESCRIPTION
ProxyCommand mode could not be used 'cause it fails with message
```
tuntox: invalid option -- 'W'
```
Looking through the code it seems you forgotten to rename that option in call to `getopt`. In switch cases it was renamed. So `-W` option is not accepted by `getopt` and `-P` passes to default case in switch and just prints version/help.