### PR TITLE
add LIB_DIR variable to mac makefile

### DIFF
--- a/Makefile.mac
+++ b/Makefile.mac
@@ -7,6 +7,7 @@ LDFLAGS=-g -lm
 LDFLAGS += $(shell pkg-config --libs $(DEPS))
 OBJECTS=$(SOURCES:.c=.o)
 INCLUDES = $(wildcard *.h)
+LIB_DIR ?= /usr/local/lib
 
 all: cscope.out tuntox 
 
@@ -19,7 +20,7 @@ gitversion.c: gitversion.h
 	$(CC) $(CFLAGS) $< -c -o $@
 
 tuntox: $(OBJECTS) $(INCLUDES)
-	$(CC) -o $@ $(OBJECTS) -ltoxcore $(LDFLAGS) /usr/local/lib/libsodium.a /usr/local/lib/libtoxcore.a
+	$(CC) -o $@ $(OBJECTS) -ltoxcore $(LDFLAGS) $(LIB_DIR)/libsodium.a $(LIB_DIR)/libtoxcore.a
 
 cscope.out:
 	cscope -bv ./*.[ch] 


### PR DESCRIPTION
Hello @gjedeer !

@jming422 and I are working on making a homebrew formula for `tuntox` to be included in [homebrew-core](https://github.com/Homebrew/homebrew-core).

We made this adjustment to the mac makefile so that the lib directory that contains `libsodium` and `libtoxcore` can be set as a variable override. 

This way, it can be set to the correct location on both intel and m1 macs.

Please let us know if this is something you would be open to.

Also, if this does get merged in, would it be possible to tag a new version that includes these changes, so that we can utilize that tarball for the homebrew formula?

Thanks!