### PR TITLE
Include print_version_stdout declaration in main.c, conditionally add -lrt flag when OS is not mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,15 +3,21 @@ DEPS=toxcore
 CC=gcc
 CFLAGS=-g -Wall #-std=c99
 CFLAGS += $(shell pkg-config --cflags $(DEPS))
-LDFLAGS=-g -pthread -lm -static -lrt
+LDFLAGS=-g -pthread -lm -static
 LDFLAGS += $(shell pkg-config --static --libs $(DEPS))
-DSO_LDFLAGS=-g -pthread -lm -lrt
+DSO_LDFLAGS=-g -pthread -lm
 DSO_LDFLAGS += $(shell pkg-config --libs $(DEPS))
 OBJECTS=$(SOURCES:.c=.o)
 INCLUDES = $(wildcard *.h)
 PYTHON = /usr/bin/env python3
 INSTALL = install -C
 INSTALL_MKDIR = $(INSTALL) -d -m 755
+OS=$(shell uname)
+
+ifneq ($(OS),Darwin)
+	LDFLAGS += -lrt
+	DSO_LDFLAGS += -lrt
+endif
 
 prefix ?= /usr
 bindir ?= $(prefix)/bin

--- a/main.h
+++ b/main.h
@@ -124,4 +124,5 @@ int send_frame(protocol_frame *frame, uint8_t *data);
 int send_tunnel_request_packet(char *remote_host, int remote_port, int friend_number);
 
 void print_version(void);
+void print_version_stdout(void);
 #endif


### PR DESCRIPTION
Hello again! Hope you're doing well.

I am still working on getting tuntox into homebrew-core

It was suggested that we adjust the standard `Makefile` so that we can utilize `make tuntox_nostatic` to build without statically linking the libs. (see here for more info https://github.com/Homebrew/homebrew-core/pull/104375). 

`Makefile` seems to work on macOS as long as we remove the `-lrt` flag.

I have added a conditional in `Makefile` to only add the `-lrt` flag if `uname` is Darwin.

Lastly, while working on this, I was running into
```
main.c:1434:17: error: implicit declaration of function 'print_version_stdout' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
                print_version_stdout();
```

I think this is because the declaration for `print_version_stdout` was missing from `main.h`. I've added it in this PR as well.

Looking forward to hearing your thoughts on this PR. Thanks! 😎 

